### PR TITLE
Revert actions runner image change

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   publishpsgallery:
     name: 'PowerShell Gallery'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       NUGET_API_KEY: ${{ secrets.NUGETAPIKEY }}
     steps:


### PR DESCRIPTION
Reverting the runner image back to ubuntu-latest following identification of the issue preventing publishing of modules.
